### PR TITLE
Fix the incompatible argument type in the PHPDoc annotation of Faq class

### DIFF
--- a/Ui/DataProvider/Faq.php
+++ b/Ui/DataProvider/Faq.php
@@ -15,9 +15,9 @@ class Faq extends AbstractDataProvider
     private array $loadedData;
 
     /**
-     * @param $name
-     * @param $primaryFieldName
-     * @param $requestFieldName
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
      * @param CollectionFactory $collectionFactory
      * @param array $meta
      * @param array $data


### PR DESCRIPTION
This pull request adds missing argument types to the PHPDoc annotation of the `Macademy\Minerva\Ui\DataProvider\Faq` class to fix the incompatible argument type issue